### PR TITLE
Bugfix: Only check required fields

### DIFF
--- a/pybump/pybump.py
+++ b/pybump/pybump.py
@@ -15,7 +15,7 @@ def is_valid_helm_chart(content):
     :param content: parsed YAML file as dictionary of key values
     :return: True if dict contains mandatory values, else False
     """
-    return all(x in content for x in ['apiVersion', 'appVersion', 'description', 'name', 'version'])
+    return all(x in content for x in ['apiVersion', 'name', 'version'])
 
 
 def get_setup_py_version(content):

--- a/pybump/pybump.py
+++ b/pybump/pybump.py
@@ -11,7 +11,8 @@ regex_version_pattern = re.compile(r"((?:__)?version(?:__)? ?= ?[\"'])(.+?)([\"'
 
 def is_valid_helm_chart(content):
     """
-    Check if input dictionary contains mandatory keys of a Helm Chart.yaml file
+    Check if input dictionary contains mandatory keys of a Helm Chart.yaml file,
+    as documented here https://helm.sh/docs/topics/charts/#the-chartyaml-file
     :param content: parsed YAML file as dictionary of key values
     :return: True if dict contains mandatory values, else False
     """
@@ -193,7 +194,13 @@ def read_version_from_file(file_path, app_version):
             # Make sure Helm chart is valid and contains minimal mandatory keys
             if is_valid_helm_chart(file_content):
                 if app_version:
-                    current_version = file_content['appVersion']
+                    current_version = file_content.get('appVersion', None)
+
+                    # user passed the 'app-version' flag, but helm chart file does not contain the 'appVersion' field
+                    if not current_version:
+                        raise ValueError(
+                            "Could not find 'appVersion' field in helm chart.yaml file: {}".format(file_content)
+                        )
                 else:
                     current_version = file_content['version']
             else:

--- a/pybump/pybump_unittest.py
+++ b/pybump/pybump_unittest.py
@@ -310,6 +310,16 @@ class PyBumpTest(unittest.TestCase):
         if stdout != "3.0.0":
             raise Exception("test_bump_patch failed, return version should be 3.0.0 got " + stdout)
 
+        # Simulate with --app-version flag on a chart with missing appVersion field
+        test_3 = simulate_bump_version("pybump/test_valid_chart_minimal.yaml", "major", True)
+
+        if test_3.returncode == 1:
+            # 'CompletedProcess' should raised exception
+            pass
+        else:
+            raise Exception("test_bump_major with missing appVersion failed, "
+                            "test should of fail with ValueError, but it passed passed")
+
     @staticmethod
     def test_invalid_bump_major():
         simulate_set_version("pybump/test_invalid_chart.yaml", "3.5.5")
@@ -367,6 +377,15 @@ class PyBumpTest(unittest.TestCase):
         stdout = completed_process_object.stdout.decode('utf-8').strip()
         if stdout != "v2.0.8-alpha.802+sha-256":
             raise Exception("test_get_flags failed, return string should be v2.0.8-alpha.802+sha-256 got " + stdout)
+
+        # Test the 'get' command with --app-version flag on a chart with missing appVersion field
+        test_5 = simulate_get_version("pybump/test_valid_chart_minimal.yaml", app_version=True)
+        if test_5.returncode == 1:
+            # 'CompletedProcess' should raised exception
+            pass
+        else:
+            raise Exception("test_get_flags with missing appVersion failed, "
+                            "test should of fail with ValueError, but it passed passed")
 
     @staticmethod
     def test_plain_text_version_file():

--- a/pybump/pybump_unittest.py
+++ b/pybump/pybump_unittest.py
@@ -11,7 +11,6 @@ valid_helm_chart = {'apiVersion': 'v1',
 invalid_helm_chart = {'apiVersion': 'v1',
                       'notAppVersionKeyHere': '1.0',
                       'description': 'A Helm chart for Kubernetes',
-                      'name': 'test',
                       'version': '0.1.0'}
 empty_helm_chart = {}
 

--- a/pybump/test_valid_chart_minimal.yaml
+++ b/pybump/test_valid_chart_minimal.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+name: test
+version: 0.1.0


### PR DESCRIPTION
The only fields that are mandatory for `Chart.yml` are apiVersion, name, and version.

According to https://helm.sh/docs/topics/charts/#the-chartyaml-file:

description: A single-sentence description of this project (optional)
appVersion: The version of the app that this contains (optional)

I have removed these from the list of required fields.