### PR TITLE
Migrate pyyaml to ruamel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-
-pyyaml==6.0
+ruamel.yaml==0.17.21
 GitPython==3.1.30
 
 # currently not in use since patch-update support dropped

--- a/src/pybump.py
+++ b/src/pybump.py
@@ -20,7 +20,9 @@ def is_valid_helm_chart(content):
     :param content: parsed YAML file as dictionary of key values
     :return: True if dict contains mandatory values, else False
     """
-    return all(x in content for x in ['apiVersion', 'name', 'version'])
+    if content is not None:
+        return all(x in content for x in ['apiVersion', 'name', 'version'])
+    return False
 
 
 def get_setup_py_version(content):

--- a/src/pybump.py
+++ b/src/pybump.py
@@ -3,7 +3,7 @@ import os
 import re
 from sys import stderr
 
-import yaml
+from ruamel.yaml import YAML, YAMLError
 from pkg_resources import get_distribution, DistributionNotFound
 try:
     from .pybump_version import PybumpVersion
@@ -80,7 +80,8 @@ def write_version_to_file(file_path, file_content, version, app_version):
                 file_content['appVersion'] = version
             else:
                 file_content['version'] = version
-            yaml.dump(file_content, outfile, default_flow_style=False, sort_keys=False)
+            yaml = YAML()
+            yaml.dump(file_content, outfile)
         elif os.path.basename(filename) == 'VERSION':
             outfile.write(version)
         outfile.close()
@@ -107,8 +108,9 @@ def read_version_from_file(file_path, app_version):
             file_type = 'python'
         elif file_extension == '.yaml' or file_extension == '.yml':  # Case Helm chart files
             try:
-                file_content = yaml.safe_load(stream)
-            except yaml.YAMLError as exc:
+                yaml = YAML()
+                file_content = yaml.load(stream)
+            except YAMLError as exc:
                 print(exc)
             # Make sure Helm chart is valid and contains minimal mandatory keys
             if is_valid_helm_chart(file_content):

--- a/test/test_content_files/test_valid_chart.yaml
+++ b/test/test_content_files/test_valid_chart.yaml
@@ -1,5 +1,19 @@
+# valid helm chart file
+# comments should stay here after YAML file handling
 apiVersion: v1
 appVersion: 2.0.3
+version: 0.1.0 # version key should stay here and not be sorted
 description: A Helm chart for Kubernetes
 name: test
-version: 0.1.0
+plainText: |-
+  some data
+  here
+mapKey:
+  a: b
+
+  # above empty line will be preserved
+  bool: true
+listKey:
+- a
+- b
+- c

--- a/test/test_pybump.py
+++ b/test/test_pybump.py
@@ -164,6 +164,7 @@ class PyBumpTest(unittest.TestCase):
         self.assertTrue(is_valid_helm_chart(valid_helm_chart))
         self.assertFalse(is_valid_helm_chart(invalid_helm_chart))
         self.assertFalse(is_valid_helm_chart(empty_helm_chart))
+        self.assertFalse(is_valid_helm_chart(None))
 
     def test_get_setup_py_version(self):
         self.assertEqual(get_setup_py_version(valid_setup_py), '0.1.3')

--- a/test/test_simulate_pybump.py
+++ b/test/test_simulate_pybump.py
@@ -289,3 +289,39 @@ class PyBumpSimulatorTest(unittest.TestCase):
                                        stdout=PIPE, stderr=PIPE)
         self.assertIs(completed_process_object.returncode, 1,
                       msg="returned a 0 exist code, but tested 'verify' flag against a non valid semver string")
+
+    def test_yaml_sort_comments_preservation(self):
+        """
+        Test case that check YAML files are not sorted or missing original inline comments after version bumps
+        :return:
+        """
+        # first "reset" version and appVersion with pre-defined values
+        simulate_set_version("test/test_content_files/test_valid_chart.yaml", "1.0.0", app_version=False)
+        simulate_set_version("test/test_content_files/test_valid_chart.yaml", "1.0.0", app_version=True)
+
+        with open("test/test_content_files/test_valid_chart.yaml", "r") as f:
+            content = f.read()
+
+        # below text must be equal to the output of test_valid_chart.yaml file after bump action
+        # this test will make sure all "# comments" preserved and key sorting did not occur
+        self.assertMultiLineEqual(
+            content,
+            '# valid helm chart file\n'
+            '# comments should stay here after YAML file handling\n'
+            'apiVersion: v1\n'
+            'appVersion: 1.0.0\n'
+            'version: 1.0.0                    # version key should stay here and not be sorted\n'
+            'description: A Helm chart for Kubernetes\n'
+            'name: test\n'
+            'plainText: |-\n'
+            '  some data\n'
+            '  here\n'
+            'mapKey:\n'
+            '  a: b\n'
+            '\n'
+            '  # above empty line will be preserved\n'
+            '  bool: true\n'
+            'listKey:\n'
+            '- a\n'
+            '- b\n'
+            '- c\n')


### PR DESCRIPTION
<!--
Thank you for contributing!

For fast feedback, please @-mention maintainers that are listed in the Chart.yaml file.

Please make sure you test your changes before you push them.
-->

# What this PR does
deprecate the usage of [pyyaml](https://github.com/yaml/pyyaml) in favor of [ruamle](https://pypi.org/project/ruamel.yaml/) due to `pyyaml` not preserving yaml comments
# Which issue this PR fixes
- fixes #41 

# Extra notes
ruamle does not remove spaces after "last char" until start of comment, so for example a YAML file with
```yaml
version: 0.1.0-metadata # some random comment here
```
with a bump action of a **shorter** version will output
```yaml
version: 0.1.1          # some random comment here
```